### PR TITLE
Don't re-query the database when using Pgvector

### DIFF
--- a/lib/langchainrb_rails/active_record/hooks.rb
+++ b/lib/langchainrb_rails/active_record/hooks.rb
@@ -99,6 +99,8 @@ module LangchainrbRails
             k: k
           )
 
+          return records if LangchainrbRails.config.vectorsearch.is_a?(Langchain::Vectorsearch::Pgvector)
+
           # We use "__id" when Weaviate is the provider
           ids = records.map { |record| record.try("id") || record.dig("__id") }
           where(id: ids)


### PR DESCRIPTION
Tentative fix for #32 

It looks like there is some provider-specific code elsewhere in the file, but additionally when using pgvector, this method ends up doing two queries to the database. 

This is just a hacky fix to get a conversation started - I noticed you have the pgvector.rb overrides file...maybe there's a similar pattern for the other vector dbs to just call the override methods instead of overloading this one with special cases for every one?