### PR TITLE
Set a Langchain::Vectorsearch::* instance on each class instead of pointing to the same object. This fixes a bug when 1+ ActiveRecord models use vectorsearch

### DIFF
--- a/lib/langchainrb_rails/active_record/hooks.rb
+++ b/lib/langchainrb_rails/active_record/hooks.rb
@@ -71,12 +71,12 @@ module LangchainrbRails
         #
         # @param provider [Object] The `Langchain::Vectorsearch::*` instance
         def vectorsearch
-          class_variable_set(:@@provider, LangchainrbRails.config.vectorsearch)
+          class_variable_set(:@@provider, LangchainrbRails.config.vectorsearch.dup)
 
           # Pgvector-specific configuration
           if LangchainrbRails.config.vectorsearch.is_a?(Langchain::Vectorsearch::Pgvector)
             has_neighbors(:embedding)
-            LangchainrbRails.config.vectorsearch.model = self
+            class_variable_get(:@@provider).model = self
           end
         end
 


### PR DESCRIPTION
…inting to the same object. This fixes a bug when 1+ ActiveRecord models use vectorsearh