### PR TITLE
Fix on `Pgvector#ask` 

### DIFF
--- a/lib/langchainrb_overrides/vectorsearch/pgvector.rb
+++ b/lib/langchainrb_overrides/vectorsearch/pgvector.rb
@@ -117,7 +117,8 @@ module Langchain::Vectorsearch
 
         prompt = generate_rag_prompt(question: question, context: context)
 
-        llm.chat(prompt: prompt, &block)
+        messages = [{ role: "user", content: prompt }]
+        llm.chat(messages: messages, &block)
       end
     end
   end

--- a/lib/langchainrb_overrides/vectorsearch/pgvector.rb
+++ b/lib/langchainrb_overrides/vectorsearch/pgvector.rb
@@ -117,7 +117,7 @@ module Langchain::Vectorsearch
 
         prompt = generate_rag_prompt(question: question, context: context)
 
-        messages = [{ role: "user", content: prompt }]
+        messages = [{role: "user", content: prompt}]
         llm.chat(messages: messages, &block)
       end
     end


### PR DESCRIPTION
Fix on `Pgvector#ask`  uses the wrong syntax of `llm.chat`.

It uses this:
```
llm.chat(prompt: prompt, &block)
```

Instead of this:
```
messages = [ { role: "user", content: prompt } ]
llm.chat(messages: messages, &block)
```

***

Ran all the linters locally
![Screenshot 2024-01-29 at 2 55 21 PM](https://github.com/andreibondarev/langchainrb_rails/assets/237025/5f755625-e2c5-42aa-b4fe-661b71511743)

