### PR TITLE
Fix Model.ask response parsing

### DIFF
--- a/lib/langchainrb_rails/active_record/hooks.rb
+++ b/lib/langchainrb_rails/active_record/hooks.rb
@@ -117,7 +117,7 @@ module LangchainrbRails
             question: question,
             k: k,
             &block
-          ).completion
+          ).chat_completion
         end
       end
     end


### PR DESCRIPTION
use `.chat_completion` instead of `.completion` when parsing `Model.ask` as it uses the chat endpoint

Some of the LLM models have identical `chat_completion` and `completion` (eg: OpenAI), while others have different response structures returned from the API (eg: Ollama)